### PR TITLE
Removes all references to dotenv because it was stopping heroku from …

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,6 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'rspec-rails', '~> 3.5'
   gem 'byebug', platform: :mri
-  # gem 'dotenv-rails'
   gem 'factory_girl_rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,7 +280,6 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   coveralls
   devise
-  dotenv-rails
   factory_girl_rails
   figaro
   jbuilder (~> 2.5)
@@ -306,4 +305,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   1.12.5
+   1.13.1

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,8 +6,6 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-# Dotenv::Railtie.load
-
 module Easycalendar
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.


### PR DESCRIPTION
…deploying the master to production